### PR TITLE
User should be able to add sites to dive journal

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField
-from wtforms.validators import DataRequired, Email, Length
+from wtforms import StringField, PasswordField, TextAreaField, SelectField
+from wtforms.validators import DataRequired, Email, Length, Optional
 
 
 class UserAddForm(FlaskForm):
@@ -16,3 +16,23 @@ class LoginForm(FlaskForm):
 
     username = StringField("Username", validators=[DataRequired()])
     password = PasswordField("Password", validators=[Length(min=8)])
+
+
+class JournalSiteForm(FlaskForm):
+    """Form to add/edit dive journal site."""
+
+    description = TextAreaField(
+        "Description (public)",
+        validators=[Optional()],
+        render_kw={"placeholder": "Share your experience with other users"},
+    )
+    notes = TextAreaField(
+        "Notes (private)",
+        validators=[Optional()],
+        render_kw={"placeholder": "Just for you, notes will remain private"},
+    )
+    rating = SelectField(
+        "Rating",
+        choices=[(1, 1), (2, 2), (3, 3), (4, 4), (5, 5)],
+        validators=[DataRequired()],
+    )

--- a/models.py
+++ b/models.py
@@ -24,6 +24,12 @@ class User(db.Model):
     password = db.Column(db.Text, nullable=False)
 
     bucket_list = db.relationship("Dive_site", secondary="bucket_list_sites")
+    dive_journal = db.relationship(
+        "Journal_entry",
+        back_populates="user",
+        cascade="all, delete, delete-orphan",
+        single_parent=True,
+    )
 
     def __repr__(self):
         """Display id, username, and email."""
@@ -65,12 +71,38 @@ class Dive_site(db.Model):
     description = db.Column(db.Text)
     location = db.Column(db.Text, nullable=False)
 
+    journal_entries = db.relationship("Journal_entry")
+
 
 class Bucket_list_site(db.Model):
     """Dive site in user's bucket list."""
 
-    __tablename__ = 'bucket_list_sites'
+    __tablename__ = "bucket_list_sites"
 
     id = db.Column(db.Integer, primary_key=True)
-    dive_site_id = db.Column(db.Integer, db.ForeignKey('dive_sites.id', ondelete='CASCADE'), nullable=False)
-    user_id = db.Column(db.Integer, db.ForeignKey('users.id', ondelete='CASCADE'), nullable=False)
+    dive_site_id = db.Column(
+        db.Integer, db.ForeignKey("dive_sites.id", ondelete="CASCADE"), nullable=False
+    )
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
+
+class Journal_entry(db.Model):
+    """Dive journal entry."""
+
+    __tablename__ = "journal_entries"
+
+    id = db.Column(db.Integer, primary_key=True)
+    dive_site_id = db.Column(
+        db.Integer, db.ForeignKey("dive_sites.id", ondelete="CASCADE"), nullable=False
+    )
+    notes = db.Column(db.Text)
+    description = db.Column(db.Text)
+    rating = db.Column(db.Integer, nullable=False)
+    user_id = db.Column(
+        db.Integer, db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+
+    user = db.relationship("User")
+    dive_site = db.relationship("Dive_site")

--- a/seed.py
+++ b/seed.py
@@ -1,7 +1,7 @@
 """Seed file to make sample data for dive db."""
 # import reverse_geocode
 
-from models import db, User, Dive_site
+from models import db, User, Dive_site, Bucket_list_site
 from app import app
 
 from sqlalchemy.schema import DropTable
@@ -40,7 +40,7 @@ db.session.add(lighthouse)
 
 db.session.commit()
 
-# bl_site = Bucket_list_site(dive_site_id=lighthouse.id, user_id=diver1.id)
+bl_site = Bucket_list_site(dive_site_id=lighthouse.id, user_id=diver1.id)
 
-# db.session.add(bl_site)
-# db.session.commit()
+db.session.add(bl_site)
+db.session.commit()

--- a/templates/dive-journal.html
+++ b/templates/dive-journal.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1 class="text-center">Dive Journal</h1>
+
+<div class="container">
+    <ul id="site-list">
+        {% for site in sites %}
+        <li><a href="/journal/{{site.id}}">{{site.dive_site.name}}</a></li>
+        {% endfor %}
+    </ul>
+</div>
+{% endblock %}

--- a/templates/journal-form.html
+++ b/templates/journal-form.html
@@ -1,0 +1,26 @@
+{% extends 'base.html' %}
+
+{% block content %}
+
+  <div class="row justify-content-md-center">
+  <div class="col-md-7 col-lg-5">
+    <h2>{{site.name}}</h2>
+    <h4>{{site.location}}</h4>
+    <form method="POST" id="user_form">
+      {{ form.hidden_tag() }}
+
+      {% for field in form if field.widget.input_type != 'hidden' %}
+        {{ field.label }}
+        {% for error in field.errors %}
+          <span class="text-danger">{{ error }}</span>
+        {% endfor %}
+        {{ field(class="form-control") }}
+      {% endfor %}
+
+      <button class="btn btn-primary"> Save </button>
+      
+    </form>
+  </div>
+</div>
+
+{% endblock %}

--- a/templates/site-detail.html
+++ b/templates/site-detail.html
@@ -21,7 +21,7 @@
             </button>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                 <button class="dropdown-item" id="bucket-list-add" data-id="{{site.id}}">Add to bucket list</button>
-                <a class="dropdown-item" href="#">Add to dive journal</a>
+                <a class="dropdown-item" href="/journal/{{site.id}}/add">Add to dive journal</a>
             </div>
         </div>
         <div id="msg"></div>


### PR DESCRIPTION
### What does this PR do?
- This PR allows users to add a dive site to their dive journal
### Description of Task to be completed
- The user clicks the save site button to add it to their dive journal, and can view their dive journal by clicking the link in the navbar.
### How should this be manually tested?
- Clone the repository
- Run seed.py file
- Log in
- Use the map or search bar to find dive sites
- Click the link for one of the search results
- Click to add to dive journal on the save site dropdown button