### PR TITLE
Remove alternate to environmental variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ import os
 load_dotenv()
 
 class Config:
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'hard to guess string'
+    SECRET_KEY = os.environ.get('SECRET_KEY')
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     SQLALCHEMY_ECHO = False
     DEBUG_TB_INTERCEPT_REDIRECTS = False
@@ -27,7 +27,7 @@ class TestingConfig(Config):
     TESTING = True
     WTF_CSRF_ENABLED = False
     MAIL_SUPPRESS_SEND = True
-    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL') or 'postgresql:///dive_test'
+    SQLALCHEMY_DATABASE_URI = os.environ.get('TEST_DATABASE_URL')
 
 class ProductionConfig(Config):
     """Configurations for Production Environment."""


### PR DESCRIPTION
### What does this PR do?
- This PR removes the alternate option for environmental variables in config.py
- Fixes #45
